### PR TITLE
Return list of transaction records instead of whole response

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
 List of tap-egencia config values
 
 ```
-  start_date: ${START_DATE}
+  start_date: ${TAP_EGENCIA_START_DATE}
     required: false
-  end_date: ${END_DATE}
+  end_date: ${TAP_EGENCIA_END_DATE}
     required: false
-  egencia_base_url: ${EGENCIA_BASE_URL}
+  egencia_base_url: ${TAP_EGENCIA_EGENCIA_BASE_URL}
     required: true
-  client_id: ${EGENCIA_CLIENT_ID}
+  client_id: ${TAP_EGENCIA_EGENCIA_CLIENT_ID}
     required: true
-  client_secret: ${EGENCIA_SECRET_ID}
+  client_secret: ${TAP_EGENCIA_EGENCIA_SECRET_ID}
     required: true
 
 ```

--- a/meltano.yml
+++ b/meltano.yml
@@ -24,8 +24,13 @@ plugins:
       - name: "egencia_base_url"
         kind: string
     config:
-      start_date: ""
-      end_date: ""
+      client_id: $CLIENT_ID
+      client_secret: $CLIENT_SECRET
+      end_date: $END_DATE
+      start_date: $START_DATE
+      egencia_base_url: $EGENCIA_BASE_URL
+      # start_date: ""
+      # end_date: ""
   loaders:
   - name: "target-jsonl"
     variant: "andyh1203"

--- a/meltano.yml
+++ b/meltano.yml
@@ -23,6 +23,9 @@ plugins:
         kind: string
       - name: "egencia_base_url"
         kind: string
+    config:
+      start_date: ""
+      end_date: ""
   loaders:
   - name: "target-jsonl"
     variant: "andyh1203"

--- a/meltano.yml
+++ b/meltano.yml
@@ -23,14 +23,6 @@ plugins:
         kind: string
       - name: "egencia_base_url"
         kind: string
-    config:
-      client_id: $CLIENT_ID
-      client_secret: $CLIENT_SECRET
-      end_date: $END_DATE
-      start_date: $START_DATE
-      egencia_base_url: $EGENCIA_BASE_URL
-      # start_date: ""
-      # end_date: ""
   loaders:
   - name: "target-jsonl"
     variant: "andyh1203"

--- a/tap_egencia/client.py
+++ b/tap_egencia/client.py
@@ -1,6 +1,11 @@
 """REST client handling, including egenciaStream base class."""
 
 from __future__ import annotations
+import json
+from typing import Any, Dict, Iterable
+
+import requests
+import datetime
 
 from pathlib import Path
 from singer_sdk.streams import RESTStream
@@ -39,3 +44,77 @@ class egenciaStream(RESTStream):
         else: 
             date = None
         return date
+    
+    def get_records(self, *args, **kwargs) -> Iterable[Dict[str, Any]]:
+        # authenticator = super().authenticator
+        # url_base = super().url_base
+        # start_date = super().start_date
+        # end_date = super().end_date
+        
+        self.path = "/bi/api/v1/transactions"
+
+        session = requests.Session()
+        session.headers = self.authenticator.auth_headers
+        session.headers["Accept"] = "application/hal+json"
+        session.headers["Content-Type"] = "application/json"
+
+        if self.start_date == None:
+            n_days_ago = datetime.datetime.now() - datetime.timedelta(7)
+            self.start_date = n_days_ago.strftime("%Y-%m-%d %H:%M:%S")
+   
+        if self.end_date == None:
+            today = datetime.datetime.now()
+            self.end_date = today.strftime("%Y-%m-%d %H:%M:%S")
+
+        self.body = {"start_date": f"{self.start_date}", "end_date": f"{self.end_date}"}
+
+        post_transaction_request = session.prepare_request(
+            requests.Request(method="POST", url=self.url_base + self.path, json=self.body)
+        )
+
+
+        post_transaction_response = self._request(post_transaction_request, None)
+
+        if post_transaction_response.status_code != 201:
+            replacementContent = { "failure-response": f"{post_transaction_response.status_code} - {post_transaction_response.reason}", "report_id": "", "metadata": {}, "transactions": [], "_links": {}}
+            
+            json_response = json.dumps(replacementContent)
+            byte_response = json_response.encode()
+            post_transaction_response._content = byte_response
+
+            return super().parse_response(post_transaction_response)
+
+        else:
+
+            report_id = post_transaction_response.json()["report_id"]
+            total_pages = post_transaction_response.json()["metadata"]["total_pages"]
+
+            self.path = f"/bi/api/v1/transactions/{report_id}?page={total_pages}"
+
+            get_transaction_request = session.prepare_request(
+                requests.Request(
+                    "GET",
+                    self.url_base + self.path,
+                ),
+            )
+
+            get_transaction_response = self._request(get_transaction_request, None)
+
+            match get_transaction_response.status_code:
+                case 200:
+                    return self.parse_response(get_transaction_response)
+                case 400:
+                    raise Exception('Bad Request: Invalid input or request')
+                case 401:
+                    raise Exception("Unauthorized: authentication token empty, invalid or expired")
+                case 403:
+                    raise Exception("Forbidden: User not Validated for operation")
+                case 405:
+                    raise Exception("Client Error: Method Not Allowed for path")
+                case 422:
+                    raise Exception("Invalid input: invalid or missing required input")
+                case 500:
+                    raise Exception("Internal Server Error: unable to process request.")
+                case _:
+                # Return Status Code, Textual Reason for error and response body of error if occurance not listed above
+                    raise Exception(get_transaction_response.status_code, get_transaction_response.reason, get_transaction_response.content)

--- a/tap_egencia/streams.py
+++ b/tap_egencia/streams.py
@@ -15,10 +15,13 @@ from singer_sdk.typing import PropertiesList, Property, StringType
 from typing import Any, Dict, Iterable
 
 
+from tap_egencia.schemas.post_transactions import linksObject
 from tap_egencia.schemas.get_transactions import (
+    metadataObject,
     paymentObject,
     policyObject,
     priceObject,
+    transactionsObject,
     travelDatesObject,
     travelerObject,
     customDataFieldsObject,
@@ -133,6 +136,94 @@ class TransactionsStream(egenciaStream):
             match get_transaction_response.status_code:
                 case 200:
                     return iter(json.loads(get_transaction_response.content.decode())["transactions"])
+                case 400:
+                    raise Exception('Bad Request: Invalid input or request')
+                case 401:
+                    raise Exception("Unauthorized: authentication token empty, invalid or expired")
+                case 403:
+                    raise Exception("Forbidden: User not Validated for operation")
+                case 405:
+                    raise Exception("Client Error: Method Not Allowed for path")
+                case 422:
+                    raise Exception("Invalid input: invalid or missing required input")
+                case 500:
+                    raise Exception("Internal Server Error: unable to process request.")
+                case _:
+                # Return Status Code, Textual Reason for error and response body of error if occurance not listed above
+                    raise Exception(get_transaction_response.status_code, get_transaction_response.reason, get_transaction_response.content)
+
+
+class TransactionsResponseStream(egenciaStream):
+    """Define reporting/transactions stream."""
+
+    name = "transactionsResponse-api"
+    schema = PropertiesList(
+        Property("failure-response", StringType),
+        Property("report_id", StringType),
+        Property("metadata", metadataObject),
+        Property("transactions", transactionsObject),
+        Property("_links", linksObject)
+    ).to_dict()
+    authenticator = None
+
+    def get_records(self, *args, **kwargs) -> Iterable[Dict[str, Any]]:
+        authenticator = super().authenticator
+        url_base = super().url_base
+        start_date = super().start_date
+        end_date = super().end_date
+        
+        self.path = "/bi/api/v1/transactions"
+
+        session = requests.Session()
+        session.headers = authenticator.auth_headers
+        session.headers["Accept"] = "application/hal+json"
+        session.headers["Content-Type"] = "application/json"
+
+        if start_date == None:
+            n_days_ago = datetime.datetime.now() - datetime.timedelta(7)
+            start_date = n_days_ago.strftime("%Y-%m-%d %H:%M:%S")
+   
+        if end_date == None:
+            today = datetime.datetime.now()
+            end_date = today.strftime("%Y-%m-%d %H:%M:%S")
+
+        self.body = {"start_date": f"{start_date}", "end_date": f"{end_date}"}
+
+        post_transaction_request = session.prepare_request(
+            requests.Request(method="POST", url=url_base + self.path, json=self.body)
+        )
+
+
+        post_transaction_response = self._request(post_transaction_request, None)
+
+        if post_transaction_response.status_code != 201:
+            replacementContent = { "failure-response": f"{post_transaction_response.status_code} - {post_transaction_response.reason}", "report_id": "", "metadata": {}, "transactions": [], "_links": {}}
+            
+            json_response = json.dumps(replacementContent)
+            byte_response = json_response.encode()
+            post_transaction_response._content = byte_response
+
+            return super().parse_response(post_transaction_response)
+
+        else:
+
+            report_id = post_transaction_response.json()["report_id"]
+            total_pages = post_transaction_response.json()["metadata"]["total_pages"]
+
+            self.path = f"/bi/api/v1/transactions/{report_id}?page={total_pages}"
+
+            get_transaction_request = session.prepare_request(
+                requests.Request(
+                    "GET",
+                    url_base + self.path,
+                ),
+            )
+
+            get_transaction_response = self._request(get_transaction_request, None)
+
+            match get_transaction_response.status_code:
+                case 200:
+                    return super().parse_response(get_transaction_response)
                 case 400:
                     raise Exception('Bad Request: Invalid input or request')
                 case 401:

--- a/tap_egencia/streams.py
+++ b/tap_egencia/streams.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import requests
-import datetime 
-
 from pathlib import Path
 import json
 
@@ -76,81 +73,9 @@ class TransactionsStream(egenciaStream):
         Property("vendor", StringType),
         Property("vendor_name", StringType)
     ).to_dict()
-    authenticator = None
 
-    def get_records(self, *args, **kwargs) -> Iterable[Dict[str, Any]]:
-        authenticator = super().authenticator
-        url_base = super().url_base
-        start_date = super().start_date
-        end_date = super().end_date
-        
-        self.path = "/bi/api/v1/transactions"
-
-        session = requests.Session()
-        session.headers = authenticator.auth_headers
-        session.headers["Accept"] = "application/hal+json"
-        session.headers["Content-Type"] = "application/json"
-
-        if start_date == None:
-            n_days_ago = datetime.datetime.now() - datetime.timedelta(7)
-            start_date = n_days_ago.strftime("%Y-%m-%d %H:%M:%S")
-   
-        if end_date == None:
-            today = datetime.datetime.now()
-            end_date = today.strftime("%Y-%m-%d %H:%M:%S")
-
-        self.body = {"start_date": f"{start_date}", "end_date": f"{end_date}"}
-
-        post_transaction_request = session.prepare_request(
-            requests.Request(method="POST", url=url_base + self.path, json=self.body)
-        )
-
-
-        post_transaction_response = self._request(post_transaction_request, None)
-
-        if post_transaction_response.status_code != 201:
-            replacementContent = { "failure-response": f"{post_transaction_response.status_code} - {post_transaction_response.reason}", "report_id": "", "metadata": {}, "transactions": [], "_links": {}}
-            
-            json_response = json.dumps(replacementContent)
-            byte_response = json_response.encode()
-            post_transaction_response._content = byte_response
-
-            return super().parse_response(post_transaction_response)
-
-        else:
-
-            report_id = post_transaction_response.json()["report_id"]
-            total_pages = post_transaction_response.json()["metadata"]["total_pages"]
-
-            self.path = f"/bi/api/v1/transactions/{report_id}?page={total_pages}"
-
-            get_transaction_request = session.prepare_request(
-                requests.Request(
-                    "GET",
-                    url_base + self.path,
-                ),
-            )
-
-            get_transaction_response = self._request(get_transaction_request, None)
-
-            match get_transaction_response.status_code:
-                case 200:
-                    return iter(json.loads(get_transaction_response.content.decode())["transactions"])
-                case 400:
-                    raise Exception('Bad Request: Invalid input or request')
-                case 401:
-                    raise Exception("Unauthorized: authentication token empty, invalid or expired")
-                case 403:
-                    raise Exception("Forbidden: User not Validated for operation")
-                case 405:
-                    raise Exception("Client Error: Method Not Allowed for path")
-                case 422:
-                    raise Exception("Invalid input: invalid or missing required input")
-                case 500:
-                    raise Exception("Internal Server Error: unable to process request.")
-                case _:
-                # Return Status Code, Textual Reason for error and response body of error if occurance not listed above
-                    raise Exception(get_transaction_response.status_code, get_transaction_response.reason, get_transaction_response.content)
+    def parse_response(self, response) -> Iterable[Dict[str, Any]]:
+        return iter(json.loads(response.content.decode())["transactions"])
 
 
 class TransactionsResponseStream(egenciaStream):
@@ -164,79 +89,6 @@ class TransactionsResponseStream(egenciaStream):
         Property("transactions", transactionsObject),
         Property("_links", linksObject)
     ).to_dict()
-    authenticator = None
 
-    def get_records(self, *args, **kwargs) -> Iterable[Dict[str, Any]]:
-        authenticator = super().authenticator
-        url_base = super().url_base
-        start_date = super().start_date
-        end_date = super().end_date
-        
-        self.path = "/bi/api/v1/transactions"
-
-        session = requests.Session()
-        session.headers = authenticator.auth_headers
-        session.headers["Accept"] = "application/hal+json"
-        session.headers["Content-Type"] = "application/json"
-
-        if start_date == None:
-            n_days_ago = datetime.datetime.now() - datetime.timedelta(7)
-            start_date = n_days_ago.strftime("%Y-%m-%d %H:%M:%S")
-   
-        if end_date == None:
-            today = datetime.datetime.now()
-            end_date = today.strftime("%Y-%m-%d %H:%M:%S")
-
-        self.body = {"start_date": f"{start_date}", "end_date": f"{end_date}"}
-
-        post_transaction_request = session.prepare_request(
-            requests.Request(method="POST", url=url_base + self.path, json=self.body)
-        )
-
-
-        post_transaction_response = self._request(post_transaction_request, None)
-
-        if post_transaction_response.status_code != 201:
-            replacementContent = { "failure-response": f"{post_transaction_response.status_code} - {post_transaction_response.reason}", "report_id": "", "metadata": {}, "transactions": [], "_links": {}}
-            
-            json_response = json.dumps(replacementContent)
-            byte_response = json_response.encode()
-            post_transaction_response._content = byte_response
-
-            return super().parse_response(post_transaction_response)
-
-        else:
-
-            report_id = post_transaction_response.json()["report_id"]
-            total_pages = post_transaction_response.json()["metadata"]["total_pages"]
-
-            self.path = f"/bi/api/v1/transactions/{report_id}?page={total_pages}"
-
-            get_transaction_request = session.prepare_request(
-                requests.Request(
-                    "GET",
-                    url_base + self.path,
-                ),
-            )
-
-            get_transaction_response = self._request(get_transaction_request, None)
-
-            match get_transaction_response.status_code:
-                case 200:
-                    return super().parse_response(get_transaction_response)
-                case 400:
-                    raise Exception('Bad Request: Invalid input or request')
-                case 401:
-                    raise Exception("Unauthorized: authentication token empty, invalid or expired")
-                case 403:
-                    raise Exception("Forbidden: User not Validated for operation")
-                case 405:
-                    raise Exception("Client Error: Method Not Allowed for path")
-                case 422:
-                    raise Exception("Invalid input: invalid or missing required input")
-                case 500:
-                    raise Exception("Internal Server Error: unable to process request.")
-                case _:
-                # Return Status Code, Textual Reason for error and response body of error if occurance not listed above
-                    raise Exception(get_transaction_response.status_code, get_transaction_response.reason, get_transaction_response.content)
-
+    def parse_response(self, response) -> Iterable[Dict[str, Any]]:
+        return super().parse_response(response)

--- a/tap_egencia/streams.py
+++ b/tap_egencia/streams.py
@@ -16,11 +16,14 @@ from typing import Any, Dict, Iterable
 
 
 from tap_egencia.schemas.get_transactions import (
-    metadataObject,
-    transactionsObject
-)
-from tap_egencia.schemas.post_transactions import (
-    linksObject
+    paymentObject,
+    policyObject,
+    priceObject,
+    travelDatesObject,
+    travelerObject,
+    customDataFieldsObject,
+    durationObject,
+    identifierObject
 )
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
@@ -31,12 +34,45 @@ class TransactionsStream(egenciaStream):
 
     name = "transactions-api"
     schema = PropertiesList(
-        Property("failure-response", StringType),
-        Property("report_id", StringType),
-        Property("metadata", metadataObject),
-        Property("transactions", transactionsObject),
-        Property("_links", linksObject)
-        ).to_dict()
+        Property("traveler", travelerObject),
+        Property("advance_purchase_days", StringType),
+        Property("advance_purchase_window", StringType),
+        Property("ancillary_type", StringType),
+        Property("booking_method", StringType),
+        Property("custom_data_fields", customDataFieldsObject),
+        Property("cabin_class_name", StringType),
+        Property("class_of_service", StringType),
+        Property("client_code", StringType),
+        Property("company_name", StringType),
+        Property("department", StringType),
+        Property("duration", durationObject),
+        Property("geography_type", StringType),
+        Property("identifier", identifierObject),
+        Property("invoice_date", StringType),
+        Property("is_active", StringType),
+        Property("is_agent_assisted", StringType),
+        Property("is_special_request", StringType),
+        Property("line_of_business", StringType),
+        Property("location", StringType),
+        Property("meeting_name", StringType),
+        Property("parent_client_code", StringType),
+        Property("payment_instrument_info", paymentObject),
+        Property("point_of_sale", StringType),
+        Property("point_of_sale_country", StringType),
+        Property("policy", policyObject),
+        Property("price", priceObject),
+        Property("purchase_count", StringType),
+        Property("rate_type", StringType),
+        Property("segment_count", StringType),
+        Property("ticket_code", StringType),
+        Property("ticket_status", StringType),
+        Property("transaction_date", StringType),
+        Property("transaction_status", StringType),
+        Property("transaction_type", StringType),
+        Property("travel_dates", travelDatesObject),
+        Property("vendor", StringType),
+        Property("vendor_name", StringType)
+    ).to_dict()
     authenticator = None
 
     def get_records(self, *args, **kwargs) -> Iterable[Dict[str, Any]]:
@@ -92,12 +128,11 @@ class TransactionsStream(egenciaStream):
                 ),
             )
 
-
             get_transaction_response = self._request(get_transaction_request, None)
 
             match get_transaction_response.status_code:
                 case 200:
-                    return super().parse_response(get_transaction_response)
+                    return iter(json.loads(get_transaction_response.content.decode())["transactions"])
                 case 400:
                     raise Exception('Bad Request: Invalid input or request')
                 case 401:

--- a/tap_egencia/tap.py
+++ b/tap_egencia/tap.py
@@ -8,10 +8,12 @@ from singer_sdk import typing as th  # JSON schema typing helpers
 
 from tap_egencia.streams import (
     TransactionsStream,
+    TransactionsResponseStream
 )
 
 STREAM_TYPES = [
     TransactionsStream,
+    TransactionsResponseStream
 ]
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,4 +14,4 @@ class TestTapEgenciaSync(unittest.TestCase):
         catalog = TapEgencia().discover_streams()
 
         # expect valid catalog to be discovered
-        self.assertEqual(len(catalog), 1, "Total streams from default catalog")
+        self.assertEqual(len(catalog), 2, "Total streams from default catalog")


### PR DESCRIPTION
This change is to have our tap return a list of transactions, each one as a record, instead of a single response record that has a list of transactions.