### PR TITLE
Stop reconciled_air crashing on empty reports and oversized windows

### DIFF
--- a/tap_egencia/client.py
+++ b/tap_egencia/client.py
@@ -24,9 +24,12 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 class HATEOASPaginator(BaseHATEOASPaginator):
     def get_next_url(self,response):
-        data = response.json()
-        if 'next' in data['_links']:
-            return data['_links']['next']['href']
+        # A missing _links block means there is no next page. Indexing it
+        # directly turns a final page into a KeyError, which aborts the stream
+        # and leaves the state file empty.
+        links = response.json().get('_links', {})
+        if 'next' in links:
+            return links['next']['href']
         else:
             return None
 
@@ -35,6 +38,19 @@ class egenciaStream(RESTStream):
 
     report_id = ""
     records_jsonpath = "$[transactions][*]"
+
+    # Egencia rejects any report request spanning more than a year with a 400.
+    # Clamping here keeps a stream recoverable after state loss: without it, a
+    # blank state file falls back to the config start_date and every subsequent
+    # run fails, because tapdance rewrites the state file empty on each crash.
+    max_window_days = 364
+
+    # Streams whose records only become available after an out-of-band
+    # reconciliation lag cannot derive their window from the bookmark: the
+    # bookmark tracks wall-clock extract time, so the next window sits in the
+    # not-yet-reconciled future and always comes back empty. Those streams set
+    # a rolling lookback instead of using the bookmark.
+    lookback_days: int | None = None
 
     @property
     def url_base(self) -> str:
@@ -76,18 +92,49 @@ class egenciaStream(RESTStream):
         self.logger.info(f'PARAMS:{params}')
         return params
     
-    def get_report_id(self,context):
+    def get_window(self, context) -> tuple[str, str]:
+        """Return the (start_date, end_date) to request, clamped to the API's limit."""
+        # Naive UTC throughout. The API and the bookmark both carry naive UTC, so
+        # a naive local now() would skew the window by the container's offset -
+        # invisible in prod only because that container happens to run in UTC.
+        end = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
+        if self.lookback_days is not None:
+            start = end - datetime.timedelta(days=self.lookback_days)
+        else:
+            # Falls back to the config start_date, and is None when neither a
+            # bookmark nor a start_date is set - start_date is not a required
+            # setting. The bookmark is naive UTC on the wire, so drop the tzinfo
+            # the SDK adds to keep it comparable with the naive end above.
+            bookmark = self.get_starting_timestamp(context)
+            start = bookmark.replace(tzinfo=None) if bookmark is not None else None
+
+        earliest_allowed = end - datetime.timedelta(days=self.max_window_days)
+        if start is None:
+            self.logger.warning(
+                f'No bookmark or start_date to sync from; requesting the widest '
+                f'window the API allows ({self.max_window_days} days).'
+            )
+            start = earliest_allowed
+        elif start < earliest_allowed:
+            self.logger.warning(
+                f'Requested start_date {start:%Y-%m-%d %H:%M:%S} is outside the API\'s '
+                f'{self.max_window_days}-day window; clamping to '
+                f'{earliest_allowed:%Y-%m-%d %H:%M:%S}.'
+            )
+            start = earliest_allowed
+
+        return start.strftime("%Y-%m-%d %H:%M:%S"), end.strftime("%Y-%m-%d %H:%M:%S")
+
+    def get_report_id(self,context) -> str | None:
+        """Create a report and return its id, or None when it holds no records."""
 
         session = requests.Session()
         session.headers = self.authenticator.auth_headers
         session.headers["Accept"] = "application/hal+json"
         session.headers["Content-Type"] = "application/json"
 
-        self.start_date = self.get_starting_timestamp(context)
-        self.start_date = self.start_date.strftime("%Y-%m-%d %H:%M:%S")
-
-        today = datetime.datetime.now()
-        self.end_date = today.strftime("%Y-%m-%d %H:%M:%S")
+        self.start_date, self.end_date = self.get_window(context)
         self.logger.info(f'start_date: {self.start_date}, end_date: {self.end_date}, lob: {self.lob}')
         self.body = {"start_date": f"{self.start_date}", "end_date": f"{self.end_date}"}
         if self.reconciled_records_only:
@@ -96,18 +143,54 @@ class egenciaStream(RESTStream):
             requests.Request(method="POST", url=self.url_base + self.path + self.lob, json=self.body)
         )
         post_transaction_response = self._request(post_transaction_request, None)
+
+        # An empty report is a normal outcome, not a failure. Raising here used to
+        # abort the stream, which left the bookmark wiped and forced the next run
+        # into a full-history pull.
+        if post_transaction_response.status_code == 204:
+            self.logger.info(
+                f'No {self.lob} records for {self.start_date} - {self.end_date}'
+                f'{" (reconciled only)" if self.reconciled_records_only else ""}; '
+                'nothing to sync.'
+            )
+            return None
+
         if post_transaction_response.status_code != 201:
-            raise Exception(f'Report was not created successfully. Status Code {post_transaction_response.status_code}')
+            raise Exception(
+                f'Report was not created successfully. Status Code '
+                f'{post_transaction_response.status_code}: {post_transaction_response.text}'
+            )
+
+        self.logger.info(f'report metadata: {post_transaction_response.json().get("metadata")}')
         report_id = post_transaction_response.json()["report_id"]
 
         return report_id
+
+    def get_records(self, context: Context | None) -> t.Iterable[dict]:
+        """Yield records for this stream, or nothing when the report is empty."""
+        report_id = self.get_report_id(context)
+        if report_id is None:
+            return
+
+        self.report_id = report_id
+        yield from super().get_records(context)
+
+    def validate_response(self, response: requests.Response) -> None:
+        """Log the API's error body before the SDK turns the status into an exception.
+
+        Egencia explains its 4xx rejections in the body only, so without this the
+        reason never reaches the container logs.
+        """
+        if 400 <= response.status_code < 500:
+            self.logger.error(
+                f'{response.status_code} from {response.request.url}: {response.text[:1000]}'
+            )
+        super().validate_response(response)
 
     def get_url(self, context: Context | None) -> str:
 
         url = "".join([self.url_base, self.path or ""])
         self.logger.info(f"report_id: {self.report_id}")
-        if self.report_id == "":
-            self.report_id = self.get_report_id(context)
         url = f"{url}/{self.report_id}"
         self.logger.info(f'URL: {url}')
         return url

--- a/tap_egencia/streams.py
+++ b/tap_egencia/streams.py
@@ -156,6 +156,12 @@ class ReconciledAirTransactionsStream(egenciaStream):
     lob  = "air"
     replication_key = "last_extracted_date"
     reconciled_records_only = True
+    # Reconciliation runs ~2 weeks behind the transaction date (the report
+    # metadata carries it as latest_reconciled_date), so a bookmark-driven window
+    # would always land in a period with nothing reconciled yet. Pull a rolling
+    # window instead and let the downstream unique_key dedup absorb the overlap.
+    # 364 days is the widest window the API accepts.
+    lookback_days = 364
     schema = th.PropertiesList(
         th.Property("last_extracted_date", th.DateTimeType),
         th.Property("traveler",th.ObjectType(

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -1,6 +1,7 @@
 """Mock API."""
 
 import json
+import re
 
 import requests_mock
 
@@ -8,23 +9,32 @@ API_URL = "https://apis.egencia.com"
 
 mock_responses_path = "tests/mock_responses"
 
+# Endpoints are patterns rather than fixed paths: report creation is per line of
+# business (/bi/api/v1/transactions/<lob>) and report pages are keyed by the id
+# the creation call hands back. Report creation answers 201, not 200.
 mock_config = {
     "authorization_token": {
         "type": "post",
-        "endpoint": "/auth/v1/token",
+        "endpoint": re.compile(r"/auth/v1/token$"),
         "file": "mock_auth.json",
+        "status": 200,
     },
     "transactions": {
         "type": "post",
-        "endpoint": "/bi/api/v1/transactions",
+        "endpoint": re.compile(r"/bi/api/v1/transactions/(air|car|fees|ground|hotel|train)$"),
         "file": "mock_transactions.json",
+        "status": 201,
     },
     "transactions-page-1": {
         "type": "get",
-        "endpoint": "/bi/api/v1/transactions/f5d4d0f8-7243-4c2d-b2ab-bce09fbf4053?page=1",
+        # `/+` because path already ends in a slash and get_url appends another,
+        # so the fetch URL carries a double slash. The API tolerates it.
+        "endpoint": re.compile(r"/bi/api/v1/transactions/+f5d4d0f8-7243-4c2d-b2ab-bce09fbf4053"),
         "file": "mock_transactions_page1.json",
-    }
+        "status": 200,
+    },
 }
+
 
 def mock_api(func):
     """Mock API."""
@@ -34,18 +44,10 @@ def mock_api(func):
             for k, v in mock_config.items():
                 path = f"{mock_responses_path}/{v['file']}"
 
-                endpoint = v["endpoint"]
-
-                url = f"{API_URL}{endpoint}"
-
                 with open(path, "r") as f:
                     response = json.load(f)
 
-                if v["type"] == "post":
-                    m.post(url, json=response)
-
-                elif v["type"] == "get":
-                    m.get(url, json=response)
+                m.request(v["type"], v["endpoint"], json=response, status_code=v["status"])
 
             func()
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,8 +1,50 @@
-# """Tests the tap using a mock base credentials config."""
+"""Tests the tap using a mock base credentials config."""
 
+import datetime
+import json
 import unittest
+from unittest import mock
 
+import requests
+
+from tap_egencia.client import egenciaStream
 from tap_egencia.tap import TapEgencia
+
+SAMPLE_CONFIG = {
+    # date format needs to be yyyy-MM-dd HH:mm:ss
+    "start_date": "2023-01-01 09:00:00",
+    "egencia_base_url": "https://apis.egencia.com",
+    "client_id": "testclientid",
+    "client_secret": "testclientsecret",
+}
+
+EXPECTED_STREAMS = {
+    "air",
+    "car",
+    "fee",
+    "ground",
+    "hotel",
+    "reconciled_air",
+    "train",
+}
+
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _response(status_code, payload=None):
+    """Build a requests.Response the way the API would return one."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.request = requests.Request(
+        method="POST", url="https://apis.egencia.com/bi/api/v1/transactions/air"
+    ).prepare()
+    if payload is not None:
+        response._content = json.dumps(payload).encode()
+    return response
+
+
+def _stream(name):
+    return next(s for s in TapEgencia(config=SAMPLE_CONFIG).discover_streams() if s.name == name)
 
 
 class TestTapEgenciaSync(unittest.TestCase):
@@ -11,7 +53,101 @@ class TestTapEgenciaSync(unittest.TestCase):
     def test_base_credentials_discovery(self):
         """Test basic discover sync"""
 
-        catalog = TapEgencia().discover_streams()
+        catalog = TapEgencia(config=SAMPLE_CONFIG).discover_streams()
 
-        # expect valid catalog to be discovered
-        self.assertEqual(len(catalog), 2, "Total streams from default catalog")
+        self.assertEqual(
+            {stream.name for stream in catalog},
+            EXPECTED_STREAMS,
+            "Streams discovered from default catalog",
+        )
+
+
+class TestRequestWindow(unittest.TestCase):
+    """The report window must stay inside the API's one-year limit."""
+
+    def _window_days(self, stream, context=None):
+        start, end = stream.get_window(context)
+        return (
+            datetime.datetime.strptime(end, DATE_FORMAT)
+            - datetime.datetime.strptime(start, DATE_FORMAT)
+        ).days
+
+    def test_reconciled_air_uses_rolling_lookback(self):
+        """reconciled_air ignores the bookmark: its records lag reconciliation."""
+        stream = _stream("reconciled_air")
+        self.assertEqual(stream.lookback_days, 364)
+
+        with mock.patch.object(
+            stream, "get_starting_timestamp", side_effect=AssertionError("bookmark used")
+        ):
+            self.assertEqual(self._window_days(stream), 364)
+
+    def test_bookmark_within_limit_is_used_as_is(self):
+        """A recent bookmark drives the window for ordinary streams."""
+        stream = _stream("air")
+        bookmark = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+
+        with mock.patch.object(stream, "get_starting_timestamp", return_value=bookmark):
+            self.assertEqual(self._window_days(stream), 2)
+
+    def test_missing_bookmark_and_start_date_does_not_crash(self):
+        """start_date is not a required setting, so the window must survive without it."""
+        config = {k: v for k, v in SAMPLE_CONFIG.items() if k != "start_date"}
+        stream = next(
+            s for s in TapEgencia(config=config).discover_streams() if s.name == "air"
+        )
+
+        self.assertIsNone(stream.get_starting_timestamp(None))
+        self.assertEqual(self._window_days(stream), stream.max_window_days)
+
+    def test_bookmark_older_than_limit_is_clamped(self):
+        """A stale bookmark is clamped rather than sent and rejected with a 400.
+
+        Without this, state loss is unrecoverable: the fallback start_date is
+        older than a year, so every subsequent run fails and rewrites the state
+        file empty again.
+        """
+        stream = _stream("air")
+        bookmark = datetime.datetime(2025, 2, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+        with mock.patch.object(stream, "get_starting_timestamp", return_value=bookmark):
+            self.assertEqual(self._window_days(stream), stream.max_window_days)
+
+
+class TestEmptyReportHandling(unittest.TestCase):
+    """HTTP 204 means the report holds no rows, which is not an error."""
+
+    def setUp(self):
+        patcher = mock.patch.object(
+            egenciaStream, "authenticator", new_callable=mock.PropertyMock
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start().return_value = mock.Mock(auth_headers={})
+
+    def test_204_yields_no_records_and_does_not_raise(self):
+        stream = _stream("reconciled_air")
+
+        with mock.patch.object(stream, "_request", return_value=_response(204)):
+            self.assertEqual(list(stream.get_records(None)), [])
+
+    def test_201_returns_the_report_id(self):
+        stream = _stream("reconciled_air")
+        payload = {"report_id": "abc-123", "metadata": {"total_pages": 2}}
+
+        with mock.patch.object(stream, "_request", return_value=_response(201, payload)):
+            self.assertEqual(stream.get_report_id(None), "abc-123")
+
+    def test_unexpected_status_raises_with_the_response_body(self):
+        """The body is where Egencia explains the rejection, so it must surface."""
+        stream = _stream("reconciled_air")
+        payload = [{"message": "exceeds the maximum allowable date range of one year"}]
+
+        with mock.patch.object(stream, "_request", return_value=_response(202, payload)):
+            with self.assertRaises(Exception) as ctx:
+                stream.get_report_id(None)
+
+        self.assertIn("maximum allowable date range", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`get_report_id` accepted only HTTP 201. An empty report answers **204**, so any run
whose window contained no matching records raised. Because the runner rewrites the
state file empty whenever the tap process dies, that crash wiped the bookmark; the
next run fell back to the config `start_date`, and its wider pull succeeded and wrote
a bookmark, so the run after it asked for a narrow window, got 204 and crashed again.

Separately, the API enforces a one-year maximum on report date ranges, which makes
that `start_date` fallback fail outright once the configured value is more than a
year old - leaving the stream with no path back to a good state.

## Changes

- **Treat 204 as zero records** rather than an error, so the bookmark survives and no
  stream can be pushed into that cycle again.
- **Clamp every request window to 364 days.** Without this, state loss is
  unrecoverable for any stream whose fallback `start_date` is older than a year:
  every subsequent run would 400 and blank the state again.
- **Give `reconciled_air` a rolling 364-day window** instead of a bookmark-driven one.
  Reconciliation runs behind the transaction date (the report metadata exposes it as
  `latest_reconciled_date`), so a window starting at the last extract time is always
  empty. Handling 204 alone would have made the tap report success while silently
  loading nothing. Downstream dedup absorbs the overlap.
- **Compute the window in naive UTC.** The bookmark is naive UTC while `now()` was
  naive local, so the window was skewed by the container's offset - masked only
  because the deployed container runs in UTC.
- **Tolerate a missing bookmark and no `start_date`**, which is reachable because
  `start_date` is not a required setting: the window falls back to the widest the API
  allows rather than raising `AttributeError` on `None`.
- **Log 4xx response bodies.** The API explains its rejections there and nowhere else,
  so the reason for a rejection never reached the logs.
- **Tolerate a missing `_links` block** when paginating, instead of `KeyError` on the
  final page.

## Tests

9 passing. Two test files were already failing before this change and are fixed here:
`test_unit.py` asserted 2 streams when 7 exist, and the report-creation mock still
pointed at the pre-lob URL and answered 200 where the code requires 201. Added
coverage for the window clamp, the rolling lookback, the missing-`start_date`
fallback, and 204.

Verified against the live API: a window inside the cap returns 201 and pages
normally; a narrow window returns 204 and yields zero records without raising; a
bookmark older than the cap is clamped and returns 201 instead of 400.

## Known limitation

The clamp silently truncates a *deliberate* long backfill - configure `start_date`
two years back and you get the most recent 364 days with only a log warning.
Honouring a longer range needs chunked sequential windows, deliberately left out of
scope here.